### PR TITLE
Add http error response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.1] - 2021-10-23
+## [1.2.0] - 2021-10-23
+
+### Added
+- Add HTTP error response. [#3](https://github.com/marcosstupnicki/go-webapplication/pull/3)
+
+## [1.1.0] - 2021-10-23
 
 ### Added
 - Add HTTP JSON response. [#2](https://github.com/marcosstupnicki/go-webapplication/pull/2)

--- a/pkg/example/main.go
+++ b/pkg/example/main.go
@@ -25,6 +25,7 @@ func main()  {
 	userGroup := app.Group("/users")
 	userGroup.Post("/", handlerPostUser)
 	userGroup.Get("/{id}", handlerGetUser)
+	userGroup.Put("/{id}", handlerUpdateUser)
 
 	err = app.Run()
 	if err != nil {
@@ -37,11 +38,16 @@ func handlerPostUser(w http.ResponseWriter, r *http.Request) {
 	dummyUser := User{Name: "dummy-user"}
 	fmt.Printf("user request: %+v", dummyUser)
 
-	gowebapp.Write(w, 201, dummyUser)
+	gowebapp.RespondWithJSON(w, 201, dummyUser)
 }
 
 func handlerGetUser(w http.ResponseWriter, r *http.Request) {
 	dummyUser := User{Name: "dummy-user"}
 
-	gowebapp.Write(w, 200, dummyUser)
+	gowebapp.RespondWithJSON(w, 200, dummyUser)
+}
+
+func handlerUpdateUser(w http.ResponseWriter, r *http.Request) {
+	// an internal error occurred ...
+	gowebapp.RespondWithError(w, 500,  "Access denied for user 'root'")
 }

--- a/pkg/response.go
+++ b/pkg/response.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 )
 
-// Write sends the response to the client.
-func Write(w http.ResponseWriter, code int, payload interface{}) error {
+// RespondWithJSON sends the response "payload" as JSON format to the client with code as status code.
+func RespondWithJSON(w http.ResponseWriter, code int, payload interface{}) error {
 	if code == 0 {
 		return ErrStatusCode0Invalid
 	}
@@ -38,4 +38,9 @@ func isBodyAllowed(status int) bool {
 	}
 
 	return true
+}
+
+// RespondWithError return error message as JSON format. Eg: {"message": "Access denied for user 'root'"}
+func RespondWithError(w http.ResponseWriter, code int, msg string) error {
+	return RespondWithJSON(w, code, map[string]string{"message": msg})
 }


### PR DESCRIPTION
## Description 
This PR adds the  respondWithJSON function to process errors following Kelvin Salton do Prado [post](https://kelvinsp.medium.com/building-and-testing-a-rest-api-in-golang-using-gorilla-mux-and-mysql-1f0518818ff6)