### PR TITLE
Refactor: remove WithLogger, simplify New(), and restore /ping endpoint

### DIFF
--- a/pkg/middlewarelogging.go
+++ b/pkg/middlewarelogging.go
@@ -33,6 +33,14 @@ func logRequestResponse(logger golog.Logger) func(http.Handler) http.Handler {
 			next.ServeHTTP(lrw, r)
 			duration := time.Since(start)
 
+			var responseBodyMap map[string]interface{}
+			responseBody := lrw.GetBody()
+			if len(responseBody) > 0 {
+				if err := json.Unmarshal(responseBody, &responseBodyMap); err != nil {
+					responseBodyMap = map[string]interface{}{"raw": string(responseBody)}
+				}
+			}
+
 			logger.Info(r.Context(), "http_request",
 				golog.Field("request", map[string]interface{}{
 					"body":    requestBodyMap,
@@ -42,7 +50,7 @@ func logRequestResponse(logger golog.Logger) func(http.Handler) http.Handler {
 					"query":   r.URL.Query(),
 				}),
 				golog.Field("response", map[string]interface{}{
-					"body":     lrw.GetBodyMap(),
+					"body":     responseBodyMap,
 					"duration": duration.Milliseconds(),
 					"headers":  lrw.Header(),
 					"status":   lrw.statusCode,
@@ -79,16 +87,4 @@ func (lrw *LoggingResponseWriter) Write(b []byte) (int, error) {
 
 func (lrw *LoggingResponseWriter) GetBody() []byte {
 	return lrw.body.Bytes()
-}
-
-func (lrw *LoggingResponseWriter) GetBodyMap() map[string]interface{} {
-	responseBody := lrw.GetBody()
-	if len(responseBody) == 0 {
-		return nil
-	}
-	var responseBodyMap map[string]interface{}
-	if err := json.Unmarshal(responseBody, &responseBodyMap); err != nil {
-		return map[string]interface{}{"raw": string(responseBody)}
-	}
-	return responseBodyMap
 }

--- a/pkg/options.go
+++ b/pkg/options.go
@@ -1,12 +1,7 @@
 package gowebapp
 
-import (
-	golog "github.com/marcosstupnicki/go-log"
-)
-
 // webAppConfig holds configurable settings for the WebApp.
 type webAppConfig struct {
-	logger      *golog.Logger
 	corsEnabled bool
 	corsOrigins []string
 }
@@ -18,14 +13,6 @@ func defaultConfig() webAppConfig {
 
 // Option is a functional option for configuring the WebApp.
 type Option func(*webAppConfig)
-
-// WithLogger sets an explicit logger. When omitted, New() creates one
-// automatically from the environment string.
-func WithLogger(l golog.Logger) Option {
-	return func(c *webAppConfig) {
-		c.logger = &l
-	}
-}
 
 // WithCORS enables CORS with the specified allowed origins.
 // Pass []string{"*"} to allow all origins.

--- a/pkg/options_test.go
+++ b/pkg/options_test.go
@@ -9,39 +9,26 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	golog "github.com/marcosstupnicki/go-log"
 )
 
 func TestDefaultConfig(t *testing.T) {
 	cfg := defaultConfig()
 	assert.False(t, cfg.corsEnabled)
-	assert.Nil(t, cfg.logger)
+	assert.Empty(t, cfg.corsOrigins)
 }
 
 func TestOptions(t *testing.T) {
 	tests := []struct {
-		name   string
-		opt    Option
-		check  func(t *testing.T, cfg webAppConfig)
+		name  string
+		opt   Option
+		check func(t *testing.T, cfg webAppConfig)
 	}{
 		{
 			name: "WithCORS enables CORS",
-			opt:  WithCORS([]string{"https://acklane.com"}),
+			opt:  WithCORS([]string{"https://example.com"}),
 			check: func(t *testing.T, cfg webAppConfig) {
 				assert.True(t, cfg.corsEnabled)
-				assert.Equal(t, []string{"https://acklane.com"}, cfg.corsOrigins)
-			},
-		},
-		{
-			name: "WithLogger sets logger",
-			opt: func() Option {
-				l, err := golog.New("test")
-				require.NoError(t, err)
-				return WithLogger(l)
-			}(),
-			check: func(t *testing.T, cfg webAppConfig) {
-				assert.NotNil(t, cfg.logger)
+				assert.Equal(t, []string{"https://example.com"}, cfg.corsOrigins)
 			},
 		},
 	}
@@ -64,9 +51,9 @@ func TestNew_Endpoints(t *testing.T) {
 		wantJSON   map[string]interface{}
 	}{
 		{
-			name:       "health endpoint returns 200",
+			name:       "ping endpoint returns 200",
 			method:     http.MethodGet,
-			path:       "/health",
+			path:       "/ping",
 			wantStatus: http.StatusOK,
 			wantJSON:   map[string]interface{}{"status": "ok"},
 		},

--- a/pkg/webapp.go
+++ b/pkg/webapp.go
@@ -23,15 +23,9 @@ func New(environment string, port string, opts ...Option) (*WebApp, error) {
 		opt(&cfg)
 	}
 
-	var logger golog.Logger
-	if cfg.logger != nil {
-		logger = *cfg.logger
-	} else {
-		var err error
-		logger, err = golog.New(environment)
-		if err != nil {
-			return nil, fmt.Errorf("gowebapp: create logger: %w", err)
-		}
+	logger, err := golog.New(environment)
+	if err != nil {
+		return nil, fmt.Errorf("gowebapp: create logger: %w", err)
 	}
 
 	scope := Scope{Environment: environment}
@@ -48,12 +42,6 @@ func New(environment string, port string, opts ...Option) (*WebApp, error) {
 // Run starts the HTTP server. Blocks until the server returns an error.
 func (wa *WebApp) Run() error {
 	return http.ListenAndServe(":"+wa.Port, wa.Router.mux)
-}
-
-// Use appends one or more middleware to the router stack.
-// Must be called before registering routes.
-func (wa *WebApp) Use(middlewares ...func(http.Handler) http.Handler) {
-	wa.Router.Use(middlewares...)
 }
 
 // Group creates a temporary scope for mounting middleware before route definitions.
@@ -94,8 +82,8 @@ func newRouter(logger golog.Logger, cfg webAppConfig) *Router {
 	// Request/response logging.
 	mux.Use(logRequestResponse(logger))
 
-	// Health check endpoint.
-	mux.Get("/health", func(w http.ResponseWriter, r *http.Request) {
+	// Ping endpoint.
+	mux.Get("/ping", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})


### PR DESCRIPTION
### Motivation
- Simplificar la gestión del logger dejando que `New(environment, port, ...)` cree siempre el logger con `golog.New(environment)` en lugar de soportar una opción externa `WithLogger` y el campo `cfg.logger`.
- Restaurar el comportamiento previo del endpoint incorporado (`/ping`) pero conservar los headers y la llamada explícita a `WriteHeader` añadidos por la refactorización de logging.
- Evitar la exposición innecesaria de API (`WebApp.Use`) y hacer el logging de respuesta más local y claro revirtiendo `GetBodyMap()` en favor de una variable local `responseBodyMap` en el middleware.

### Description
- Eliminado `WithLogger` y el campo `logger` de `webAppConfig` en `pkg/options.go` para quitar la opción de pasar un logger externo.
- Simplificado `New` en `pkg/webapp.go` para crear el logger siempre con `golog.New(environment)` y eliminar la rama condicional sobre `cfg.logger`.
- Eliminado el método receptor `func (wa *WebApp) Use(...)` en `pkg/webapp.go` para no duplicar la API de router; la funcionalidad de `Use` queda en el `Router`.
- Restaurado el endpoint integrado a `GET /ping` en `pkg/webapp.go` manteniendo `Content-Type` y `WriteHeader(http.StatusOK)`; además, el middleware de logging ahora parsea la respuesta a una variable local `responseBodyMap` y se removió `GetBodyMap()` de `pkg/middlewarelogging.go`.
- Actualizados tests en `pkg/options_test.go` para reemplazar `https://acklane.com` por `https://example.com` y ajustar las expectativas a los cambios de la API.

### Testing
- Ejecutado `go test ./...` y todos los tests automatizados pasaron exitosamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed0251e99883218c0404118ee88171)