### PR TITLE
Adjust access log body shape

### DIFF
--- a/pkg/middlewarelogging.go
+++ b/pkg/middlewarelogging.go
@@ -22,18 +22,13 @@ func logRequestResponse(logger golog.Logger) func(http.Handler) http.Handler {
 			if r.Body != nil {
 				bodyBytes, _ := io.ReadAll(r.Body)
 				r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
-
-				if len(bodyBytes) > 0 {
-					var parsed map[string]any
-					if err := json.Unmarshal(bodyBytes, &parsed); err == nil {
-						requestBody = parsed
-					} else {
-						requestBody = map[string]any{"raw": string(bodyBytes)}
-					}
-				}
+				requestBody = parseLogBody(bodyBytes)
 			}
 
 			ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
+			var responseBody bytes.Buffer
+			ww.Tee(&responseBody)
+
 			next.ServeHTTP(ww, r)
 			duration := time.Since(start)
 
@@ -46,17 +41,28 @@ func logRequestResponse(logger golog.Logger) func(http.Handler) http.Handler {
 				golog.Field("request", map[string]any{
 					"body":    requestBody,
 					"headers": r.Header,
-					"method":  r.Method,
-					"path":    r.URL.Path,
 					"query":   r.URL.Query(),
 				}),
 				golog.Field("response", map[string]any{
-					"headers":     ww.Header(),
-					"status":      status,
-					"bytes":       ww.BytesWritten(),
-					"duration_ms": duration.Milliseconds(),
+					"body":     parseLogBody(responseBody.Bytes()),
+					"duration": duration.Milliseconds(),
+					"headers":  ww.Header(),
+					"status":   status,
 				}),
 			)
 		})
 	}
+}
+
+func parseLogBody(body []byte) any {
+	if len(body) == 0 {
+		return nil
+	}
+
+	var parsed any
+	if err := json.Unmarshal(body, &parsed); err == nil {
+		return parsed
+	}
+
+	return string(body)
 }

--- a/pkg/middlewarelogging_test.go
+++ b/pkg/middlewarelogging_test.go
@@ -1,0 +1,72 @@
+package gowebapp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogRequestResponseShapesRequestAndResponseBodies(t *testing.T) {
+	output := captureStderr(t, func() {
+		webapp := mustNew(t, "test", "8080")
+		webapp.Post("/hooks/{sourceID}", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = w.Write([]byte(`{"accepted":true,"provider":"xml"}`))
+		})
+
+		req := httptest.NewRequest(http.MethodPost, "/hooks/source-xml?provider=custom", strings.NewReader(`<event id="xml_local">ok</event>`))
+		req.Header.Set("Content-Type", "application/xml")
+		rr := httptest.NewRecorder()
+
+		webapp.Router.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusAccepted, rr.Code)
+	})
+
+	entry := logEntryByMessage(t, output, "http_request")
+
+	require.Equal(t, http.MethodPost, entry["method"])
+	require.Equal(t, "/hooks/source-xml", entry["path"])
+
+	request, ok := entry["request"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, `<event id="xml_local">ok</event>`, request["body"])
+	require.NotContains(t, request, "method")
+	require.NotContains(t, request, "path")
+
+	response, ok := entry["response"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, float64(http.StatusAccepted), response["status"])
+	require.Contains(t, response, "duration")
+	require.NotContains(t, response, "bytes")
+	require.NotContains(t, response, "duration_ms")
+
+	body, ok := response["body"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, true, body["accepted"])
+	require.Equal(t, "xml", body["provider"])
+}
+
+func logEntryByMessage(t *testing.T, output string, msg string) map[string]any {
+	t.Helper()
+
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		if line == "" {
+			continue
+		}
+
+		var entry map[string]any
+		require.NoError(t, json.Unmarshal([]byte(line), &entry))
+		if entry["msg"] == msg {
+			return entry
+		}
+	}
+
+	t.Fatalf("log entry with msg %q not found in output:\n%s", msg, output)
+	return nil
+}


### PR DESCRIPTION
## Summary
- Log non-JSON request/response bodies as raw strings instead of wrapping them in `{ "raw": ... }`.
- Keep `method` and `path` only at the root access-log level to avoid duplicating them inside `request`.
- Capture and log `response.body`, rename `duration_ms` to `duration`, and remove `response.bytes`.
- Add a regression test for the resulting access-log shape.

## Verification
- `go test ./...`
- `go vet ./...`