### PR TITLE
Configure HTTP logging and core middleware

### DIFF
--- a/pkg/middlewarelogging.go
+++ b/pkg/middlewarelogging.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"net/url"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5/middleware"
@@ -13,21 +15,27 @@ import (
 
 // logRequestResponse creates middleware that logs every HTTP request and
 // response with request details, response metadata, and duration.
-func logRequestResponse(logger golog.Logger) func(http.Handler) http.Handler {
+func logRequestResponse(logger golog.Logger, config HTTPLoggingConfig) func(http.Handler) http.Handler {
+	config = normalizeHTTPLoggingConfig(config)
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			start := time.Now()
 
 			var requestBody any
-			if r.Body != nil {
-				bodyBytes, _ := io.ReadAll(r.Body)
-				r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
-				requestBody = parseLogBody(bodyBytes)
+			if config.IncludeRequestBody && r.Body != nil {
+				readBytes, logBytes, truncated, err := readBodyPrefix(r.Body, config.MaxBodyBytes)
+				if err == nil {
+					r.Body = prependReadCloser(readBytes, r.Body)
+					requestBody = parseLogBody(logBytes, truncated)
+				}
 			}
 
 			ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
-			var responseBody bytes.Buffer
-			ww.Tee(&responseBody)
+			var responseBody *limitedBuffer
+			if config.IncludeResponseBody {
+				responseBody = newLimitedBuffer(config.MaxBodyBytes)
+				ww.Tee(responseBody)
+			}
 
 			next.ServeHTTP(ww, r)
 			duration := time.Since(start)
@@ -37,32 +45,167 @@ func logRequestResponse(logger golog.Logger) func(http.Handler) http.Handler {
 				status = http.StatusOK
 			}
 
+			request := map[string]any{}
+			if config.IncludeRequestBody {
+				request["body"] = requestBody
+			}
+			if config.IncludeRequestHeaders {
+				request["headers"] = redactHeaders(r.Header, config.RedactedHeaders)
+			}
+			if config.IncludeRequestQuery {
+				request["query"] = redactValues(r.URL.Query(), config.RedactedQueryParams)
+			}
+
+			response := map[string]any{
+				"duration": duration.Milliseconds(),
+				"status":   status,
+			}
+			if config.IncludeResponseBody && responseBody != nil {
+				response["body"] = parseLogBody(responseBody.Bytes(), responseBody.Truncated())
+			}
+			if config.IncludeResponseHeaders {
+				response["headers"] = redactHeaders(ww.Header(), config.RedactedHeaders)
+			}
+
 			logger.Info(r.Context(), "http_request",
-				golog.Field("request", map[string]any{
-					"body":    requestBody,
-					"headers": r.Header,
-					"query":   r.URL.Query(),
-				}),
-				golog.Field("response", map[string]any{
-					"body":     parseLogBody(responseBody.Bytes()),
-					"duration": duration.Milliseconds(),
-					"headers":  ww.Header(),
-					"status":   status,
-				}),
+				golog.Field("request", request),
+				golog.Field("response", response),
 			)
 		})
 	}
 }
 
-func parseLogBody(body []byte) any {
+func parseLogBody(body []byte, truncated bool) any {
 	if len(body) == 0 {
 		return nil
 	}
 
+	var value any
 	var parsed any
 	if err := json.Unmarshal(body, &parsed); err == nil {
-		return parsed
+		value = parsed
+	} else {
+		value = string(body)
 	}
 
-	return string(body)
+	if !truncated {
+		return value
+	}
+
+	return map[string]any{
+		"truncated": true,
+		"value":     value,
+	}
+}
+
+func readBodyPrefix(body io.Reader, limit int64) ([]byte, []byte, bool, error) {
+	if limit <= 0 {
+		return nil, nil, false, nil
+	}
+	readBytes, err := io.ReadAll(io.LimitReader(body, limit+1))
+	if err != nil {
+		return nil, nil, false, err
+	}
+	if int64(len(readBytes)) > limit {
+		return readBytes, readBytes[:limit], true, nil
+	}
+	return readBytes, readBytes, false, nil
+}
+
+type prependCloser struct {
+	reader io.Reader
+	closer io.Closer
+}
+
+func prependReadCloser(prefix []byte, body io.ReadCloser) io.ReadCloser {
+	return &prependCloser{
+		reader: io.MultiReader(bytes.NewReader(prefix), body),
+		closer: body,
+	}
+}
+
+func (p *prependCloser) Read(b []byte) (int, error) {
+	return p.reader.Read(b)
+}
+
+func (p *prependCloser) Close() error {
+	return p.closer.Close()
+}
+
+type limitedBuffer struct {
+	buf       bytes.Buffer
+	limit     int64
+	truncated bool
+}
+
+func newLimitedBuffer(limit int64) *limitedBuffer {
+	return &limitedBuffer{limit: limit}
+}
+
+func (b *limitedBuffer) Write(p []byte) (int, error) {
+	if b.limit <= 0 {
+		b.truncated = b.truncated || len(p) > 0
+		return len(p), nil
+	}
+
+	remaining := b.limit - int64(b.buf.Len())
+	if remaining <= 0 {
+		b.truncated = b.truncated || len(p) > 0
+		return len(p), nil
+	}
+	if int64(len(p)) > remaining {
+		_, _ = b.buf.Write(p[:remaining])
+		b.truncated = true
+		return len(p), nil
+	}
+	_, _ = b.buf.Write(p)
+	return len(p), nil
+}
+
+func (b *limitedBuffer) Bytes() []byte {
+	return b.buf.Bytes()
+}
+
+func (b *limitedBuffer) Truncated() bool {
+	return b.truncated
+}
+
+func redactHeaders(headers http.Header, redacted []string) map[string][]string {
+	if headers == nil {
+		return nil
+	}
+	redactedSet := stringSet(redacted)
+	out := make(map[string][]string, len(headers))
+	for key, values := range headers {
+		if _, ok := redactedSet[strings.ToLower(key)]; ok {
+			out[key] = []string{"[REDACTED]"}
+			continue
+		}
+		out[key] = cloneStringSlice(values)
+	}
+	return out
+}
+
+func redactValues(values url.Values, redacted []string) map[string][]string {
+	if values == nil {
+		return nil
+	}
+	redactedSet := stringSet(redacted)
+	out := make(map[string][]string, len(values))
+	for key, value := range values {
+		if _, ok := redactedSet[strings.ToLower(key)]; ok {
+			out[key] = []string{"[REDACTED]"}
+			continue
+		}
+		out[key] = cloneStringSlice(value)
+	}
+	return out
+}
+
+func stringSet(values []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		out[strings.ToLower(value)] = struct{}{}
+	}
+	return out
 }

--- a/pkg/middlewarelogging_test.go
+++ b/pkg/middlewarelogging_test.go
@@ -2,6 +2,7 @@ package gowebapp
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -12,7 +13,7 @@ import (
 
 func TestLogRequestResponseShapesRequestAndResponseBodies(t *testing.T) {
 	output := captureStderr(t, func() {
-		webapp := mustNew(t, "test", "8080")
+		webapp := mustNew(t, "test", "8080", WithHTTPLogging(VerboseHTTPLoggingConfig()))
 		webapp.Post("/hooks/{sourceID}", func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusAccepted)
@@ -50,6 +51,104 @@ func TestLogRequestResponseShapesRequestAndResponseBodies(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, true, body["accepted"])
 	require.Equal(t, "xml", body["provider"])
+}
+
+func TestLogRequestResponseDefaultOmitsSensitiveDetails(t *testing.T) {
+	output := captureStderr(t, func() {
+		webapp := mustNew(t, "test", "8080")
+		webapp.Post("/hooks", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = w.Write([]byte(`{"secret":"response"}`))
+		})
+
+		req := httptest.NewRequest(http.MethodPost, "/hooks?token=secret-token", strings.NewReader(`{"secret":"request"}`))
+		req.Header.Set("Authorization", "Bearer secret-token")
+		rr := httptest.NewRecorder()
+
+		webapp.Router.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusAccepted, rr.Code)
+	})
+
+	entry := logEntryByMessage(t, output, "http_request")
+	request, ok := entry["request"].(map[string]any)
+	require.True(t, ok)
+	require.Empty(t, request)
+
+	response, ok := entry["response"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, float64(http.StatusAccepted), response["status"])
+	require.Contains(t, response, "duration")
+	require.NotContains(t, response, "body")
+	require.NotContains(t, response, "headers")
+}
+
+func TestLogRequestResponseRedactsHeadersAndQuery(t *testing.T) {
+	output := captureStderr(t, func() {
+		webapp := mustNew(t, "test", "8080", WithHTTPLogging(HTTPLoggingConfig{
+			Enabled:                true,
+			IncludeRequestHeaders:  true,
+			IncludeRequestQuery:    true,
+			IncludeResponseHeaders: true,
+		}))
+		webapp.Get("/hooks", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Set-Cookie", "session=secret")
+			w.WriteHeader(http.StatusNoContent)
+		})
+
+		req := httptest.NewRequest(http.MethodGet, "/hooks?token=secret-token&provider=stripe", nil)
+		req.Header.Set("Authorization", "Bearer secret-token")
+		req.Header.Set("X-Trace", "visible")
+		rr := httptest.NewRecorder()
+
+		webapp.Router.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusNoContent, rr.Code)
+	})
+
+	entry := logEntryByMessage(t, output, "http_request")
+	request := entry["request"].(map[string]any)
+	headers := request["headers"].(map[string]any)
+	query := request["query"].(map[string]any)
+	require.Equal(t, []any{"[REDACTED]"}, headers["Authorization"])
+	require.Equal(t, []any{"visible"}, headers["X-Trace"])
+	require.Equal(t, []any{"[REDACTED]"}, query["token"])
+	require.Equal(t, []any{"stripe"}, query["provider"])
+
+	response := entry["response"].(map[string]any)
+	responseHeaders := response["headers"].(map[string]any)
+	require.Equal(t, []any{"[REDACTED]"}, responseHeaders["Set-Cookie"])
+}
+
+func TestLogRequestResponseTruncatesRequestBodyWithoutChangingHandlerBody(t *testing.T) {
+	const body = "abcdef"
+
+	output := captureStderr(t, func() {
+		webapp := mustNew(t, "test", "8080", WithHTTPLogging(HTTPLoggingConfig{
+			Enabled:            true,
+			IncludeRequestBody: true,
+			MaxBodyBytes:       3,
+		}))
+		webapp.Post("/hooks", func(w http.ResponseWriter, r *http.Request) {
+			got, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			require.Equal(t, body, string(got))
+			w.WriteHeader(http.StatusNoContent)
+		})
+
+		req := httptest.NewRequest(http.MethodPost, "/hooks", strings.NewReader(body))
+		rr := httptest.NewRecorder()
+
+		webapp.Router.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusNoContent, rr.Code)
+	})
+
+	entry := logEntryByMessage(t, output, "http_request")
+	request := entry["request"].(map[string]any)
+	loggedBody := request["body"].(map[string]any)
+	require.Equal(t, true, loggedBody["truncated"])
+	require.Equal(t, "abc", loggedBody["value"])
 }
 
 func logEntryByMessage(t *testing.T, output string, msg string) map[string]any {

--- a/pkg/options.go
+++ b/pkg/options.go
@@ -1,17 +1,42 @@
 package gowebapp
 
+import (
+	golog "github.com/marcosstupnicki/go-log"
+	"go.uber.org/zap/zapcore"
+)
+
+const defaultHTTPLogBodyLimitBytes int64 = 4 << 10
+
 // webAppConfig holds configurable settings for the WebApp.
 type webAppConfig struct {
 	corsEnabled        bool
 	corsOrigins        []string
 	corsAllowedHeaders []string
 	securityHeaders    map[string]string
+	httpLogging        HTTPLoggingConfig
+	realIPEnabled      bool
+	loggerOptions      []golog.LogOption
+}
+
+// HTTPLoggingConfig controls the built-in access log middleware.
+type HTTPLoggingConfig struct {
+	Enabled                bool
+	IncludeRequestHeaders  bool
+	IncludeRequestQuery    bool
+	IncludeRequestBody     bool
+	IncludeResponseHeaders bool
+	IncludeResponseBody    bool
+	MaxBodyBytes           int64
+	RedactedHeaders        []string
+	RedactedQueryParams    []string
 }
 
 // defaultConfig returns sensible defaults.
 func defaultConfig() webAppConfig {
 	return webAppConfig{
 		corsAllowedHeaders: []string{"Accept", "Authorization", "Content-Type", "X-Request-ID"},
+		httpLogging:        DefaultHTTPLoggingConfig(),
+		realIPEnabled:      true,
 	}
 }
 
@@ -40,6 +65,99 @@ func WithSecurityHeaders(headers map[string]string) Option {
 	return func(c *webAppConfig) {
 		c.securityHeaders = cloneHeaderMap(headers)
 	}
+}
+
+// WithHTTPLogging configures the built-in access log middleware.
+func WithHTTPLogging(config HTTPLoggingConfig) Option {
+	return func(c *webAppConfig) {
+		c.httpLogging = normalizeHTTPLoggingConfig(config)
+	}
+}
+
+// WithoutHTTPLogging disables the built-in access log middleware.
+func WithoutHTTPLogging() Option {
+	return func(c *webAppConfig) {
+		c.httpLogging = HTTPLoggingConfig{}
+	}
+}
+
+// WithRealIP controls whether chi's RealIP middleware is installed.
+//
+// RealIP trusts forwarding headers such as X-Forwarded-For. Disable it when
+// the app can receive direct untrusted traffic and let a trusted edge proxy
+// normalize the remote address instead.
+func WithRealIP(enabled bool) Option {
+	return func(c *webAppConfig) {
+		c.realIPEnabled = enabled
+	}
+}
+
+// WithLogLevel sets the minimum log level for the default go-log logger.
+func WithLogLevel(level zapcore.Level) Option {
+	return func(c *webAppConfig) {
+		c.loggerOptions = append(c.loggerOptions, golog.WithLevel(level))
+	}
+}
+
+// DefaultHTTPLoggingConfig returns a conservative access-log configuration.
+// Request and response bodies, headers, and query params are opt-in because
+// they often contain secrets or personal data.
+func DefaultHTTPLoggingConfig() HTTPLoggingConfig {
+	return HTTPLoggingConfig{
+		Enabled:      true,
+		MaxBodyBytes: defaultHTTPLogBodyLimitBytes,
+		RedactedHeaders: []string{
+			"Authorization",
+			"Cookie",
+			"Proxy-Authorization",
+			"Set-Cookie",
+			"X-Api-Key",
+			"X-Auth-Token",
+			"X-Service-Key",
+		},
+		RedactedQueryParams: []string{
+			"access_token",
+			"api_key",
+			"client_secret",
+			"code",
+			"password",
+			"secret",
+			"token",
+		},
+	}
+}
+
+// VerboseHTTPLoggingConfig includes bodies, headers, and query params with
+// redaction and bounded body capture. It is useful for local debugging.
+func VerboseHTTPLoggingConfig() HTTPLoggingConfig {
+	cfg := DefaultHTTPLoggingConfig()
+	cfg.IncludeRequestHeaders = true
+	cfg.IncludeRequestQuery = true
+	cfg.IncludeRequestBody = true
+	cfg.IncludeResponseHeaders = true
+	cfg.IncludeResponseBody = true
+	cfg.MaxBodyBytes = 64 << 10
+	return cfg
+}
+
+func normalizeHTTPLoggingConfig(config HTTPLoggingConfig) HTTPLoggingConfig {
+	if !config.Enabled {
+		return HTTPLoggingConfig{}
+	}
+	if config.MaxBodyBytes <= 0 {
+		config.MaxBodyBytes = defaultHTTPLogBodyLimitBytes
+	}
+	if config.RedactedHeaders == nil {
+		config.RedactedHeaders = DefaultHTTPLoggingConfig().RedactedHeaders
+	} else {
+		config.RedactedHeaders = cloneStringSlice(config.RedactedHeaders)
+	}
+	if config.RedactedQueryParams == nil {
+		config.RedactedQueryParams = DefaultHTTPLoggingConfig().RedactedQueryParams
+	} else {
+		config.RedactedQueryParams = cloneStringSlice(config.RedactedQueryParams)
+	}
+	return config
 }
 
 func cloneStringSlice(values []string) []string {

--- a/pkg/options_test.go
+++ b/pkg/options_test.go
@@ -17,6 +17,11 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Empty(t, cfg.corsOrigins)
 	assert.Equal(t, []string{"Accept", "Authorization", "Content-Type", "X-Request-ID"}, cfg.corsAllowedHeaders)
 	assert.Empty(t, cfg.securityHeaders)
+	assert.True(t, cfg.httpLogging.Enabled)
+	assert.False(t, cfg.httpLogging.IncludeRequestBody)
+	assert.False(t, cfg.httpLogging.IncludeRequestHeaders)
+	assert.False(t, cfg.httpLogging.IncludeResponseBody)
+	assert.True(t, cfg.realIPEnabled)
 }
 
 func TestOptions(t *testing.T) {
@@ -45,6 +50,37 @@ func TestOptions(t *testing.T) {
 			opt:  WithSecurityHeaders(map[string]string{"X-Test": "ok"}),
 			check: func(t *testing.T, cfg webAppConfig) {
 				assert.Equal(t, map[string]string{"X-Test": "ok"}, cfg.securityHeaders)
+			},
+		},
+		{
+			name: "WithHTTPLogging configures access logs",
+			opt: WithHTTPLogging(HTTPLoggingConfig{
+				Enabled:               true,
+				IncludeRequestHeaders: true,
+				IncludeRequestBody:    true,
+				MaxBodyBytes:          128,
+				RedactedHeaders:       []string{"Authorization"},
+			}),
+			check: func(t *testing.T, cfg webAppConfig) {
+				assert.True(t, cfg.httpLogging.Enabled)
+				assert.True(t, cfg.httpLogging.IncludeRequestHeaders)
+				assert.True(t, cfg.httpLogging.IncludeRequestBody)
+				assert.Equal(t, int64(128), cfg.httpLogging.MaxBodyBytes)
+				assert.Equal(t, []string{"Authorization"}, cfg.httpLogging.RedactedHeaders)
+			},
+		},
+		{
+			name: "WithoutHTTPLogging disables access logs",
+			opt:  WithoutHTTPLogging(),
+			check: func(t *testing.T, cfg webAppConfig) {
+				assert.False(t, cfg.httpLogging.Enabled)
+			},
+		},
+		{
+			name: "WithRealIP disables RealIP",
+			opt:  WithRealIP(false),
+			check: func(t *testing.T, cfg webAppConfig) {
+				assert.False(t, cfg.realIPEnabled)
 			},
 		},
 	}

--- a/pkg/webapp.go
+++ b/pkg/webapp.go
@@ -31,7 +31,7 @@ func New(environment string, port string, opts ...Option) (*WebApp, error) {
 		opt(&cfg)
 	}
 
-	logger, err := golog.New(environment)
+	logger, err := golog.New(environment, cfg.loggerOptions...)
 	if err != nil {
 		return nil, fmt.Errorf("gowebapp: create logger: %w", err)
 	}
@@ -121,14 +121,18 @@ func newRouter(logger golog.Logger, cfg webAppConfig) *Router {
 
 	// Core middleware
 	mux.Use(middleware.RequestID)
-	mux.Use(middleware.RealIP)
+	if cfg.realIPEnabled {
+		mux.Use(middleware.RealIP)
+	}
 
 	// Context enrichment: adds request_id, method, path to context
 	// so downstream logger.Info(ctx, ...) calls include these fields.
 	mux.Use(enrichContextMiddleware)
 
 	// Request/response logging wraps recoverer so panic responses are logged.
-	mux.Use(logRequestResponse(logger))
+	if cfg.httpLogging.Enabled {
+		mux.Use(logRequestResponse(logger, cfg.httpLogging))
+	}
 	mux.Use(middleware.Recoverer)
 
 	if hasSecurityHeaders(cfg.securityHeaders) {


### PR DESCRIPTION
## Summary
- Add configurable HTTP access logging with safe defaults, redaction, and bounded body capture.
- Add opt-in verbose logging for request/response bodies, headers, and query params.
- Add `WithRealIP` and `WithLogLevel` options so services can avoid trusting proxy headers and honor configured log levels.

## Validation
- `go test ./...`